### PR TITLE
Allow custom function injection

### DIFF
--- a/django_libsass.py
+++ b/django_libsass.py
@@ -54,10 +54,10 @@ def compile(**kwargs):
         INCLUDE_PATHS = get_include_paths()
 
     kwargs = kwargs.copy()
-    kwargs['include_paths'] = kwargs.get('include_paths', []) + INCLUDE_PATHS
+    kwargs['include_paths'] = (kwargs.get('include_paths') or []) + INCLUDE_PATHS
 
     custom_functions = CUSTOM_FUNCTIONS.copy()
-    custom_functions.update(kwargs.get('custom_functions', {}))
+    custom_functions.update(kwargs.get('custom_functions') or {}))
     kwargs['custom_functions'] = custom_functions
 
     return sass.compile(**kwargs)

--- a/django_libsass.py
+++ b/django_libsass.py
@@ -57,7 +57,7 @@ def compile(**kwargs):
     kwargs['include_paths'] = (kwargs.get('include_paths') or []) + INCLUDE_PATHS
 
     custom_functions = CUSTOM_FUNCTIONS.copy()
-    custom_functions.update(kwargs.get('custom_functions') or {}))
+    custom_functions.update(kwargs.get('custom_functions') or {})
     kwargs['custom_functions'] = custom_functions
 
     return sass.compile(**kwargs)

--- a/django_libsass.py
+++ b/django_libsass.py
@@ -1,11 +1,23 @@
 from django.conf import settings
 from django.contrib.staticfiles.finders import get_finders
+from django.templatetags.static import static as django_static
 
 import sass
 from compressor.filters.base import FilterBase
 
+
+def static(path):
+    """
+    Use the Django builtin static file resolver to return an absolute path
+    usable as CSS url() argument. Sass equivalent of the 'static' template
+    tag.
+    """
+    return '"{}"'.format(django_static(path))
+
+
 OUTPUT_STYLE = getattr(settings, 'LIBSASS_OUTPUT_STYLE', 'nested')
 SOURCE_COMMENTS = getattr(settings, 'LIBSASS_SOURCE_COMMENTS', settings.DEBUG)
+CUSTOM_FUNCTIONS = getattr(settings, 'LIBSASS_CUSTOM_FUNCTIONS', {'static': static})
 
 
 def get_include_paths():
@@ -42,7 +54,12 @@ def compile(**kwargs):
         INCLUDE_PATHS = get_include_paths()
 
     kwargs = kwargs.copy()
-    kwargs['include_paths'] = (kwargs.get('include_paths') or []) + INCLUDE_PATHS
+    kwargs['include_paths'] = kwargs.get('include_paths', []) + INCLUDE_PATHS
+
+    custom_functions = CUSTOM_FUNCTIONS.copy()
+    custom_functions.update(kwargs.get('custom_functions', {}))
+    kwargs['custom_functions'] = custom_functions
+
     return sass.compile(**kwargs)
 
 
@@ -59,4 +76,3 @@ class SassCompiler(FilterBase):
         else:
             return compile(string=self.content,
                            output_style=OUTPUT_STYLE)
-


### PR DESCRIPTION
Add a LIBSASS_CUSTOM_FUNCTIONS parameter to the project settings.
This dictionary maps function names to callables that should be added to your Sass compiler.

By default, a 'static' function is added to the Sass environment, which mimics the 'static' template tag.