### PR TITLE
Use staticfiles app for static if possible

### DIFF
--- a/django_libsass.py
+++ b/django_libsass.py
@@ -1,6 +1,9 @@
 from django.conf import settings
 from django.contrib.staticfiles.finders import get_finders
-from django.templatetags.static import static as django_static
+try:
+    from django.contrib.staticfiles.templatetags.staticfiles import static as django_static
+except ImportError:
+    from django.templatetags.static import static as django_static
 
 import sass
 from compressor.filters.base import FilterBase


### PR DESCRIPTION
Django allows for more complicated staticfiles than just STATIC_URL + path, such as automatically including hashes in filenames. By importing the correct static tag, we can include this behavior.