### PR TITLE
Add sourcemap support

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.5-dev
+-------
+ * Added sourcemap support
+
 0.4 (24.08.2015)
 ~~~~~~~~~~~~~~~~
  * Added support for custom functions (Alexandre Pocquet)

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,8 @@ The following settings can be used to control django-libsass's behaviour:
 * ``LIBSASS_SOURCE_COMMENTS`` - whether to enable SASS source comments (adds comments about source lines). Defaults to ``True`` when Django's ``DEBUG`` is ``True``, ``False`` otherwise.
 * ``LIBSASS_OUTPUT_STYLE`` - SASS output style. Options are ``'nested'``, ``'expanded'``, ``'compact'`` and ``'compressed'``, although as of libsass 3.0.2 only ``'nested'`` and ``'compressed'`` are implemented. Default is 'nested'. See `SASS documentation for output styles <http://sass-lang.com/documentation/file.SASS_REFERENCE.html#output_style>`_. Note that `django-compressor's settings <http://django-compressor.readthedocs.org/en/latest/settings/>`_ may also affect the formatting of the resulting CSS.
 * ``LIBSASS_CUSTOM_FUNCTIONS`` - A mapping of custom functions to be made available within the SASS compiler. By default, a ``static`` function is provided, analogous to Django's ``static`` template tag.
+* ``LIBSASS_SOURCEMAPS`` - Enable embedding sourcemaps into file output. ``LIBSASS_SOURCEMAP_PREFIX`` must also be set when sourcemaps are enabled.
+* ``LIBSASS_SOURCEMAP_PREFIX`` - URL prefix where your source files can be located, eg. ``/static/scss``. This option is needed to properly prefix source file links.
 
 Custom functions
 ~~~~~~~~~~~~~~~~

--- a/django_libsass.py
+++ b/django_libsass.py
@@ -70,7 +70,7 @@ def prefix_sourcemap(sourcemap, prefix):
 
 def embed_sourcemap(output, sourcemap):
     encoded_sourcemap = base64.standard_b64encode(
-        bytes(sourcemap, 'utf-8')
+        sourcemap.encode('utf-8')
     )
     sourcemap_fragment = 'sourceMappingURL=data:application/json;base64,{} '\
         .format(encoded_sourcemap.decode('utf-8'))

--- a/django_libsass.py
+++ b/django_libsass.py
@@ -1,5 +1,10 @@
+import base64
+import json
+import re
+import os
 from django.conf import settings
 from django.contrib.staticfiles.finders import get_finders
+from django.core.exceptions import ImproperlyConfigured
 from django.templatetags.static import static as django_static
 
 import sass
@@ -18,6 +23,12 @@ def static(path):
 OUTPUT_STYLE = getattr(settings, 'LIBSASS_OUTPUT_STYLE', 'nested')
 SOURCE_COMMENTS = getattr(settings, 'LIBSASS_SOURCE_COMMENTS', settings.DEBUG)
 CUSTOM_FUNCTIONS = getattr(settings, 'LIBSASS_CUSTOM_FUNCTIONS', {'static': static})
+SOURCEMAPS = getattr(settings, 'LIBSASS_SOURCEMAPS', False)
+SOURCEMAP_PREFIX = getattr(settings, 'LIBSASS_SOURCEMAP_PREFIX', None)
+
+if SOURCEMAPS and SOURCEMAP_PREFIX is None:
+    raise ImproperlyConfigured('LIBSASS_SOURCEMAP_PREFIX must be set when'
+                               ' LIBSASS_SOURCEMAPS = True')
 
 
 def get_include_paths():
@@ -48,6 +59,27 @@ def get_include_paths():
 INCLUDE_PATHS = None  # populate this on first call to 'compile'
 
 
+def prefix_sourcemap(sourcemap, prefix):
+    decoded_sourcemap = json.loads(sourcemap)
+    sources = ['/'.join([prefix, source])
+               for source in decoded_sourcemap['sources']]
+
+    decoded_sourcemap['sources'] = sources
+    return json.dumps(decoded_sourcemap)
+
+
+def embed_sourcemap(output, sourcemap):
+    encoded_sourcemap = base64.standard_b64encode(
+        bytes(sourcemap, 'utf-8')
+    )
+    sourcemap_fragment = 'sourceMappingURL=data:application/json;base64,{} '\
+        .format(encoded_sourcemap.decode('utf-8'))
+    url_re = re.compile(r'sourceMappingURL=[^\s]+', re.M)
+    output = url_re.sub(sourcemap_fragment, output)
+
+    return output
+
+
 def compile(**kwargs):
     """Perform sass.compile, but with the appropriate include_paths for Django added"""
     global INCLUDE_PATHS
@@ -61,7 +93,21 @@ def compile(**kwargs):
     custom_functions.update(kwargs.get('custom_functions', {}))
     kwargs['custom_functions'] = custom_functions
 
-    return sass.compile(**kwargs)
+    if SOURCEMAPS and kwargs.get('filename', None):
+        # We need to pass source_map_file to libsass so it generates
+        # correct paths to source files.
+        prefix = os.path.dirname(kwargs['filename'])
+        sourcemap_filename = os.path.join(prefix, 'sourcemap.map')
+        kwargs['source_map_filename'] = sourcemap_filename
+
+        libsass_output, sourcemap = sass.compile(**kwargs)
+        # Prefix sourcemap output with SOURCEMAP_PREFIX, which
+        # will be something like STATIC_URL/scss
+        sourcemap = prefix_sourcemap(sourcemap, SOURCEMAP_PREFIX)
+        output = embed_sourcemap(libsass_output, sourcemap)
+    else:
+        output = sass.compile(**kwargs)
+    return output
 
 
 class SassCompiler(FilterBase):


### PR DESCRIPTION
Embed sourcemaps into libsass output as base64-encoded strings.

While libsass has sourcemap support, it only supports external
sourcemaps. Unfortunately we can only use embedded sourcemaps because
django-compress abstracts output files away from plugins.

This patch uses filename supplied by django-compress to have libsass generate
initial sourcemap paths, then prefixes them with user-specified static
url to generate final urls to user-specified files before embedding.

Tested with Python 3.4, don't have a ready-to-go 2.7 project to test on at the moment.