### PR TITLE
Use kwargs for call to FilterBase super

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.6-dev
+~~~~~~~~~~~~~~~~
+ * Fixed call to FilterBase super because they've added an additional parameter
+
 0.5 (18.11.2015)
 ~~~~~~~~~~~~~~~~
  * Added sourcemap support (Saulius Žemaitaitis)

--- a/django_libsass.py
+++ b/django_libsass.py
@@ -126,7 +126,9 @@ def compile(**kwargs):
 class SassCompiler(FilterBase):
     def __init__(self, content, attrs=None, filter_type=None, charset=None, filename=None):
         # FilterBase doesn't handle being passed attrs, so fiddle the signature
-        super(SassCompiler, self).__init__(content, filter_type, filename)
+        super(SassCompiler, self).__init__(content=content,
+                                           filter_type=filter_type,
+                                           filename=filename)
 
     def input(self, **kwargs):
         if self.filename:


### PR DESCRIPTION
Compressor has added a new attr parameter so now the filename was being
passed as filter_type.