### PR TITLE
include LICENSE file in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license-file = LICENSE


### PR DESCRIPTION
Redistributions of your source code are supposed to include the `LICENSE` text under the terms of your license, but your distributions currently don't -- this makes it harder for everyone to follow the license. :)

The `MANIFEST.in` file makes sure that `LICENSE` ends up in the `.tar.gz` source files from `sdist`, and the `setup.cfg` setting tells wheels about it.