### PR TITLE
Update for Django 3.0

### DIFF
--- a/django_libsass.py
+++ b/django_libsass.py
@@ -4,7 +4,7 @@ import re
 import os
 from django.conf import settings
 from django.contrib.staticfiles.finders import get_finders
-from django.contrib.staticfiles.templatetags.staticfiles import static as django_static
+from django.templatetags import static as django_static
 
 import sass
 from compressor.filters.base import FilterBase


### PR DESCRIPTION
`django.contrib.staticfiles.templatetags.staticfiles` no longer exists in Django 3.0